### PR TITLE
Relax dependency on torch to allow 2-series

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "numpy >=1.18,<2",
     "scikit-learn >=1.0,<2",
-    "torch >= 1.7,<2",
+    "torch >= 1.7,<3",
     "typing-extensions >= 4.0.1,<5",
 ]
 dynamic = ["version", "description"]


### PR DESCRIPTION
Now that PyTorch 2.0 is finally here, it's been [confirmed to be 100% backward compatible with version 1.X](https://pytorch.org/get-started/pytorch-2.0/). Therefore, the version constraint on `torch` could be relaxed to allow using it with the 2-series.